### PR TITLE
Enable bsc mainnet and testnet as a supported network

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holographxyz/networks",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "description": "Holograph Protocol",
   "license": "SEE LICENSE IN LICENSE.md",
   "author": "@holographxyz",

--- a/src/networks.ts
+++ b/src/networks.ts
@@ -1145,7 +1145,7 @@ export const networks: Networks = {
     explorer: 'https://testnet.bscscan.com',
     lzEndpoint: '0x6Fcb97553D41516Cb228ac03FdC8B9a0a9df04A1'.toLowerCase(),
     lzId: 10102,
-    active: false,
+    active: true,
     protocolMultisig: undefined,
   } as Network,
   ethereumTestnetRinkeby: {
@@ -1196,7 +1196,7 @@ export const networks: Networks = {
     explorer: 'https://bscscan.com',
     lzEndpoint: '0x3c2269811836af69497E5F486A85D7316753cf62'.toLowerCase(),
     lzId: 102,
-    active: false,
+    active: true,
     protocolMultisig: undefined,
   } as Network,
   avalanche: {


### PR DESCRIPTION
Enable BSC mainnet and testnet as a supported network